### PR TITLE
replace ExponentOfPrime with PValuation

### DIFF
--- a/lib/rcwagrp.gi
+++ b/lib/rcwagrp.gi
@@ -3468,7 +3468,7 @@ InstallMethod( RespectedPartition,
     primes_multdiv := Difference(primes_multdiv,[1]);
     primes_onlymod := Difference(primes,primes_multdiv);
     m := Lcm(List(gens,Mod));
-    powers_impossible := List(primes_onlymod,p->p^(ExponentOfPrime(m,p)+1));
+    powers_impossible := List(primes_onlymod,p->p^(PValuation(m,p)+1));
     modulibound := 2^20;
     compute_moduli();
     P := List(AsUnionOfFewClasses(Difference(Integers,Support(G))),
@@ -6019,7 +6019,7 @@ InstallMethod( ShortResidueClassOrbits,
 
     moduli := ValueOption("moduli");
     if moduli = fail then
-      powers_impossible := List(primes_onlymod,p->p^(ExponentOfPrime(m,p)+1));
+      powers_impossible := List(primes_onlymod,p->p^(PValuation(m,p)+1));
       moduli    := AllSmoothIntegers(primes,modulusbound);
       moduli    := Filtered(moduli,m->ForAll(powers_impossible,q->m mod q<>0));
     fi;


### PR DESCRIPTION
In Utils issue #16 it is pointed out that the GAP library function PValuation does the same thing as the Utils function ExponentOfPrime, and the latter was transferred to Utils from the RCWA package. 
It is stated in the Utils package that no change will be made to transferred functions without the consent of the original package authors - so this is a request for such permission. 
In the development version of Utils the code for ExponentOfPrime has been replaced with a call to PValuation and ExponentOfPrime has been marked as obsolete and liable to removal in due course. 
The test results of ExponentOfPrime in Utils are not affected by this change. 
This PR replaces the two occurrences of ExponentOfPrime in rcwagrp.gi with PValuation.  The function does not appear to occur elsewhere.  A run of RCWA's testall.g results in only one diff: 
########> Diff in /Applications/gap/my-dev/pkg/rcwa/tst/integral.tst:2994
# Input is:
A := AutGroupGraph(gamma);
# Expected output:
<permutation group with 5 generators>
# But found:
Group([ (18,24), (16,23), (4,22), (10,25), (2,12) ])
########
and it does not seem likely that this diff is caused by the change in this PR.  