### PR TITLE
Stop using (Un)HideGlobalVariables

### DIFF
--- a/lib/rcwaaux.g
+++ b/lib/rcwaaux.g
@@ -105,13 +105,11 @@ BindGlobal( "RCWADoThingsToBeDoneBeforeTest",
     SetAssertionLevel(0);
     RESCLASSES_VIEWINGFORMAT_BACKUP := RESCLASSES_VIEWINGFORMAT;;
     ResidueClassUnionViewingFormat("short");
-    CallFuncList(HideGlobalVariables,ONE_LETTER_GLOBALS);
   end );
 
 BindGlobal( "RCWADoThingsToBeDoneAfterTest",
 
   function ( )
-    CallFuncList(UnhideGlobalVariables,ONE_LETTER_GLOBALS);
     ResidueClassUnionViewingFormat(RESCLASSES_VIEWINGFORMAT_BACKUP);
     SetAssertionLevel(RESCLASSES_ASSERTIONLEVEL_BACKUP);
     SetInfoLevel(InfoWarning,RESCLASSES_WARNINGLEVEL_BACKUP);


### PR DESCRIPTION
These functions are marked as obsolete in GAP master, which causes
warnings to appear when using them. Calling them was only used for
tests, and I could not see why. So it seems reasonable to disable this.