### PR TITLE
Remove/replace Is{Perfect,Solvable,Simple} methods

### DIFF
--- a/doc/algs.xml
+++ b/doc/algs.xml
@@ -727,7 +727,7 @@ algorithms and methods can be found in&nbsp;<Cite Key="Kohl08b"/>.
   </Item>
 
   <Mark>
-    <C>IsPerfect(<A>G</A>)</C>
+    <C>IsPerfectGroup(<A>G</A>)</C>
   </Mark>
   <Item>
     If the group <A>G</A> is trivial, then return <C>true</C>.
@@ -776,7 +776,7 @@ algorithms and methods can be found in&nbsp;<Cite Key="Kohl08b"/>.
   </Item>
 
   <Mark>
-    <C>IsSolvable(<A>G</A>)</C>
+    <C>IsSolvableGroup(<A>G</A>)</C>
   </Mark>
   <Item>
     If <A>G</A> is abelian, then return <C>true</C>.

--- a/doc/rcwagrp.xml
+++ b/doc/rcwagrp.xml
@@ -473,7 +473,7 @@ This group is handled as a special case as well:
 <![CDATA[
 gap> CT_Z := CT(Integers);
 CT(Z)
-gap> IsSimple(CT_Z); # One of a number of stored attributes/properties.
+gap> IsSimpleGroup(CT_Z); # One of a number of stored attributes/properties.
 true
 gap> V := CT([2],Integers);
 CT_[ 2 ](Z)
@@ -736,8 +736,8 @@ false
 ]]>
 </Example>
 
-<Index Key="IsSolvable" Subkey="for an rcwa group"><C>IsSolvable</C></Index>
-<Index Key="IsPerfect"  Subkey="for an rcwa group"><C>IsPerfect</C></Index>
+<Index Key="IsSolvableGroup" Subkey="for an rcwa group"><C>IsSolvableGroup</C></Index>
+<Index Key="IsPerfectGroup"  Subkey="for an rcwa group"><C>IsPerfectGroup</C></Index>
 <Index Key="DerivedSubgroup" Subkey="of an rcwa group">
   <C>DerivedSubgroup</C>
 </Index>
@@ -747,8 +747,8 @@ false
 </Index>
 <Index Key="Exponent" Subkey="of an rcwa group"><C>Exponent</C></Index>
 
-For tame rcwa groups, there are methods for <C>IsSolvable</C> and
-<C>IsPerfect</C> available, and usually derived subgroups and subgroup
+For tame rcwa groups, there are methods for <C>IsSolvableGroup</C> and
+<C>IsPerfectGroup</C> available, and usually derived subgroups and subgroup
 indices can be computed as well. Linear representations of tame groups
 over the rationals can be determined by the operation
 <C>IsomorphismMatrixGroup</C>. Testing a wild group for solvability
@@ -1780,7 +1780,7 @@ There are a couple of attributes which a priori make only sense for tame
 rcwa groups. With their help, various structural information about a given
 such group can be obtained.
 We have already seen above that there are for example methods for
-<C>IsSolvable</C>, <C>IsPerfect</C> and <C>DerivedSubgroup</C> available
+<C>IsSolvableGroup</C>, <C>IsPerfectGroup</C> and <C>DerivedSubgroup</C> available
 for tame rcwa groups, while testing wild groups for solvability or
 perfectness is currently not always feasible. The purpose of this section
 is to describe the specific attributes of tame groups which are needed for

--- a/lib/rcwagrp.gi
+++ b/lib/rcwagrp.gi
@@ -6474,8 +6474,8 @@ InstallMethod( Factorization,
 
 #############################################################################
 ##
-#S  Methods for `AbelianInvariants', `IsSolvable', `IsPerfect', `IsSimple' //
-#S  and `Exponent'. /////////////////////////////////////////////////////////
+#S  Methods for `AbelianInvariants', `IsSolvableGroup', `IsPerfectGroup',
+#S `IsSimpleGroup' and `Exponent'.
 ##
 #############################################################################
 
@@ -6502,50 +6502,22 @@ InstallMethod( AbelianInvariants,
 
 #############################################################################
 ##
-#M  IsSolvable( <G> ) . . . . . . . . . . . . . . . default method for groups
+#M  IsSolvableGroup( <G> ) . . . . . . . . . . . . . . . . .  for rcwa groups
 ##
-InstallMethod( IsSolvable,
-               "default method for groups (RCWA)", true, [ IsGroup ],
-               SUM_FLAGS,
-
-  function ( G )
-    if   HasIsSolvableGroup(G)
-    then return IsSolvableGroup(G);
-    else TryNextMethod(); fi;
-  end );
-
-#############################################################################
-##
-#M  IsSolvable( <G> ) . . . . . . . . . . . . . . . . . . . . for rcwa groups
-##
-InstallMethod( IsSolvable,
+InstallMethod( IsSolvableGroup,
                "for rcwa groups (RCWA)", ReturnTrue, [ IsRcwaGroup ], 0,
 
   function ( G )
     if IsAbelian(G) then return true; fi;
     if not IsTame(G) then TryNextMethod(); fi;
-    return IsSolvable(ActionOnRespectedPartition(G));
+    return IsSolvableGroup(ActionOnRespectedPartition(G));
   end );
 
 #############################################################################
 ##
-#M  IsPerfect( <G> ) . . . . . . . . . . . . . . .  default method for groups
+#M  IsPerfectGroup( <G> ) . . . . . . . . . . . . . . . . . . for rcwa groups
 ##
-InstallMethod( IsPerfect,
-               "default method for groups (RCWA)", true, [ IsGroup ],
-               SUM_FLAGS,
-
-  function ( G )
-    if   HasIsPerfectGroup(G)
-    then return IsPerfectGroup(G);
-    else TryNextMethod(); fi;
-  end );
-
-#############################################################################
-##
-#M  IsPerfect( <G> ) . . . . . . . . . . . . . . . . . . . .  for rcwa groups
-##
-InstallMethod( IsPerfect,
+InstallMethod( IsPerfectGroup,
                "for rcwa groups (RCWA)", ReturnTrue, [ IsRcwaGroup ], 0,
 
   function ( G )
@@ -6566,29 +6538,15 @@ InstallMethod( IsPerfect,
                                        Lcm(List(GeneratorsOfGroup(G),
                                                 Modulus))),64);
     quots := List(orbs,orb->Action(G,orb));
-    if not ForAll(quots,IsPerfect) then return false; fi;
+    if not ForAll(quots,IsPerfectGroup) then return false; fi;
 
-    if IsFinite(G) then return IsPerfect(Image(IsomorphismPermGroup(G))); fi;
+    if IsFinite(G) then return IsPerfectGroup(Image(IsomorphismPermGroup(G))); fi;
 
     if not IsTame(G) then TryNextMethod(); fi;
 
     H := ActionOnRespectedPartition(G);
     if   IsTransitive(H,[1..LargestMovedPoint(H)])
-    then return IsPerfect(H); else TryNextMethod(); fi;
-  end );
-
-#############################################################################
-##
-#M  IsSimple( <G> ) . . . . . . . . . . . . . . . . default method for groups
-##
-InstallMethod( IsSimple,
-               "default method for groups (RCWA)", true, [ IsGroup ],
-               SUM_FLAGS,
-
-  function ( G )
-    if   HasIsSimpleGroup(G)
-    then return IsSimpleGroup(G);
-    else TryNextMethod(); fi;
+    then return IsPerfectGroup(H); else TryNextMethod(); fi;
   end );
 
 #############################################################################
@@ -6612,7 +6570,7 @@ InstallMethod( IsSimpleGroup,
     fi;
     interval := Intersection(interval,Support(G));
 
-    if   ShortOrbits(G,interval,64) <> [] or not IsPerfect(G)
+    if   ShortOrbits(G,interval,64) <> [] or not IsPerfectGroup(G)
     then return false; fi;
 
     if IsTame(G) then


### PR DESCRIPTION
The GAP library already installs methods to delegate these to
Is{Perfect,Solvable,Simple}Group, so there is no need to install such
delegation methods here -- we remove them.

Moreover, actual method (which do work) should be installed for
Is{Perfect,Solvable,Simple}Group so that all callers actually end
up calling them, not just those which call the convenience operations
Is{Perfect,Solvable,Simple}.