### PR TITLE
Clean up category implications, fix warnings in GAP 4.11

### DIFF
--- a/lib/rcwagrp.gd
+++ b/lib/rcwagrp.gd
@@ -86,11 +86,11 @@ DeclareGlobalFunction( "RCWA" );
 #P  IsNaturalRCWA_Z_pi( <G> )  . . . . . . . . . . . . . . . . RCWA( Z_(pi) )
 #P  IsNaturalRCWA_GFqx( <G> )  . . . . . . . . . . . . . . . RCWA( GF(q)[x] )
 ##
-DeclareProperty( "IsNaturalRCWA", IsRcwaGroup );
-DeclareProperty( "IsNaturalRCWA_Z", IsRcwaGroup );
-DeclareProperty( "IsNaturalRCWA_ZxZ", IsRcwaGroup );
-DeclareProperty( "IsNaturalRCWA_Z_pi", IsRcwaGroup );
-DeclareProperty( "IsNaturalRCWA_GFqx", IsRcwaGroup );
+DeclareCategory( "IsNaturalRCWA", IsRcwaGroup );
+DeclareCategory( "IsNaturalRCWA_Z", IsRcwaGroup );
+DeclareCategory( "IsNaturalRCWA_ZxZ", IsRcwaGroup );
+DeclareCategory( "IsNaturalRCWA_Z_pi", IsRcwaGroup );
+DeclareCategory( "IsNaturalRCWA_GFqx", IsRcwaGroup );
 
 #############################################################################
 ##
@@ -145,12 +145,12 @@ DeclareGlobalFunction( "CT" );
 #P  IsNaturalCT_Z_pi( <G> )  . . . . . . . . . . . . . . . . . . CT( Z_(pi) )
 #P  IsNaturalCT_GFqx( <G> )  . . . . . . . . . . . . . . . . . CT( GF(q)[x] )
 ##
-DeclareProperty( "IsNaturalCT", IsRcwaGroup );
-DeclareProperty( "IsNaturalCT_Z", IsRcwaGroup );
-DeclareProperty( "IsNaturalCTP_Z", IsRcwaGroup );
-DeclareProperty( "IsNaturalCT_ZxZ", IsRcwaGroup );
-DeclareProperty( "IsNaturalCT_Z_pi", IsRcwaGroup );
-DeclareProperty( "IsNaturalCT_GFqx", IsRcwaGroup );
+DeclareCategory( "IsNaturalCT", IsRcwaGroup );
+DeclareCategory( "IsNaturalCT_Z", IsRcwaGroup );
+DeclareCategory( "IsNaturalCTP_Z", IsRcwaGroup );
+DeclareCategory( "IsNaturalCT_ZxZ", IsRcwaGroup );
+DeclareCategory( "IsNaturalCT_Z_pi", IsRcwaGroup );
+DeclareCategory( "IsNaturalCT_GFqx", IsRcwaGroup );
 
 #############################################################################
 ## 
@@ -173,7 +173,7 @@ DeclareAttribute( "DecompositionIntoPermutationalAndOrderPreservingElement",
 ##
 #P  IsNaturalRCWA_OR_CT( <G> ) . . . . . . . . . . . . . RCWA( R ) or CT( R )
 ##
-DeclareProperty( "IsNaturalRCWA_OR_CT", IsRcwaGroup );
+DeclareCategory( "IsNaturalRCWA_OR_CT", IsRcwaGroup );
 
 #############################################################################
 ##
@@ -694,7 +694,7 @@ DeclareOperation( "RefinementSequence",
 ##
 #P  IsNaturalRcwaRepresentationOfGLOrSL
 ##
-DeclareProperty( "IsNaturalRcwaRepresentationOfGLOrSL",
+DeclareCategory( "IsNaturalRcwaRepresentationOfGLOrSL",
                   IsGroupHomomorphism and IsBijective );
 
 #############################################################################

--- a/lib/rcwagrp.gd
+++ b/lib/rcwagrp.gd
@@ -191,10 +191,13 @@ DeclareProperty( "IsNaturalRCWA_OR_CT", IsRcwaGroup );
 ##  Returns a faithful rcwa representation of the group <G> over
 ##  the ring <R>, respectively over Z.
 ##
-DeclareOperation( "IsomorphismRcwaGroup", [ IsGroup, IsRing ] );
 DeclareOperation( "IsomorphismRcwaGroup", [ IsGroup, IsResidueClass ] );
 DeclareOperation( "IsomorphismRcwaGroup", [ IsGroup ] );
 DeclareAttribute( "IsomorphismRcwaGroupOverZ", IsGroup );
+
+# every ring is a residue class in itself; several InstallMethod calls for
+# IsomorphismRcwaGroup rely on this implication
+InstallTrueMethod( IsResidueClass, IsRing );
 
 #############################################################################
 ##

--- a/lib/rcwagrp.gi
+++ b/lib/rcwagrp.gi
@@ -142,8 +142,8 @@ InstallMethod( SparseRepresentation,
     then SetIsPerfectGroup(G_sparse,IsPerfectGroup(G)); fi;
     if   HasIsSimpleGroup(G)
     then SetIsSimpleGroup(G_sparse,IsSimpleGroup(G)); fi;
-    if   HasIsNaturalCTP_Z(G)
-    then SetIsNaturalCTP_Z(G_sparse,IsNaturalCTP_Z(G)); fi;
+    if   IsNaturalCTP_Z(G)
+    then SetFilterObj(G_sparse,IsNaturalCTP_Z); fi;
     return G_sparse;
   end );
 
@@ -175,8 +175,8 @@ InstallMethod( StandardRepresentation,
     then SetIsPerfectGroup(G_standard,IsPerfectGroup(G)); fi;
     if   HasIsSimpleGroup(G)
     then SetIsSimpleGroup(G_standard,IsSimpleGroup(G)); fi;
-    if   HasIsNaturalCTP_Z(G)
-    then SetIsNaturalCTP_Z(G_standard,IsNaturalCTP_Z(G)); fi;
+    if   IsNaturalCTP_Z(G)
+    then SetFilterObj(G_standard,IsNaturalCTP_Z); fi;
     return G_standard;
   end );
 
@@ -414,9 +414,9 @@ InstallMethod( RCWACons,
                      rec( ) );
     SetIsTrivial( G, false );
     SetOne( G, IdentityRcwaMappingOfZ );
-    SetIsNaturalRCWA_OR_CT( G, true );
-    SetIsNaturalRCWA( G, true );
-    SetIsNaturalRCWA_Z( G, true );
+    SetFilterObj( G, IsNaturalRCWA_OR_CT );
+    SetFilterObj( G, IsNaturalRCWA );
+    SetFilterObj( G, IsNaturalRCWA_Z );
     SetModulusOfRcwaMonoid( G, 0 );
     SetMultiplier( G, infinity );
     SetDivisor( G, infinity );
@@ -456,9 +456,9 @@ InstallMethod( RCWACons,
                      rec( ) );
     SetIsTrivial( G, false );
     SetOne( G, id );
-    SetIsNaturalRCWA_OR_CT( G, true );
-    SetIsNaturalRCWA( G, true );
-    SetIsNaturalRCWA_ZxZ( G, true );
+    SetFilterObj( G, IsNaturalRCWA_OR_CT );
+    SetFilterObj( G, IsNaturalRCWA );
+    SetFilterObj( G, IsNaturalRCWA_ZxZ );
     SetModulusOfRcwaMonoid( G, [ [ 0, 0 ], [ 0, 0 ] ] );
     SetMultiplier( G, infinity );
     SetDivisor( G, infinity );
@@ -498,9 +498,9 @@ InstallMethod( RCWACons,
                      rec( ) );
     SetIsTrivial( G, false );
     SetOne( G, id );
-    SetIsNaturalRCWA_OR_CT( G, true );
-    SetIsNaturalRCWA( G, true );
-    SetIsNaturalRCWA_Z_pi( G, true );
+    SetFilterObj( G, IsNaturalRCWA_OR_CT );
+    SetFilterObj( G, IsNaturalRCWA );
+    SetFilterObj( G, IsNaturalRCWA_Z_pi );
     SetModulusOfRcwaMonoid( G, 0 );
     SetMultiplier( G, infinity );
     SetDivisor( G, infinity );
@@ -538,9 +538,9 @@ InstallMethod( RCWACons,
                      rec( ) );
     SetIsTrivial( G, false );
     SetOne( G, id );
-    SetIsNaturalRCWA_OR_CT( G, true );
-    SetIsNaturalRCWA( G, true );
-    SetIsNaturalRCWA_GFqx( G, true );
+    SetFilterObj( G, IsNaturalRCWA_OR_CT );
+    SetFilterObj( G, IsNaturalRCWA );
+    SetFilterObj( G, IsNaturalRCWA_GFqx );
     SetModulusOfRcwaMonoid( G, Zero( R ) );
     SetMultiplier( G, infinity );
     SetDivisor( G, infinity );
@@ -563,22 +563,6 @@ InstallMethod( RCWACons,
 #F  RCWA( <R> ) . . . . . . . . . . . . . . . . . . . . . . . . . . RCWA( R )
 ##
 InstallGlobalFunction( RCWA, R -> RCWACons( IsRcwaGroup, R ) );
-
-#############################################################################
-##
-#M  IsNaturalRCWA( <G> ) . . . . . . . . . . . . . . . . . . . . . .  RCWA(R)
-#M  IsNaturalRCWA_Z( <G> ) . . . . . . . . . . . . . . . . . . . . .  RCWA(Z)
-#M  IsNaturalRCWA_Z_pi( <G> ) . . . . . . . . . . . . . . . . .  RCWA(Z_(pi))
-#M  IsNaturalRCWA_GFqx( <G> ) . . . . . . . . . . . . . . . .  RCWA(GF(q)[x])
-##
-##  The groups RCWA( <R> ) can only be obtained by the above constructors.
-##
-Perform( [ IsNaturalRCWA,
-           IsNaturalRCWA_Z, IsNaturalRCWA_Z_pi, IsNaturalRCWA_GFqx ],
-         function ( property )
-           InstallMethod( property, "for rcwa groups (RCWA)", true,
-                          [ IsRcwaGroup ], 0, ReturnFalse );
-         end );
 
 #############################################################################
 ##
@@ -608,9 +592,9 @@ InstallMethod( CTCons,
                      rec( ) );
     SetIsTrivial( G, false );
     SetOne( G, SparseRep( IdentityRcwaMappingOfZ ) );
-    SetIsNaturalRCWA_OR_CT( G, true );
-    SetIsNaturalCT( G, true );
-    SetIsNaturalCT_Z( G, true );
+    SetFilterObj( G, IsNaturalRCWA_OR_CT );
+    SetFilterObj( G, IsNaturalCT );
+    SetFilterObj( G, IsNaturalCT_Z );
     SetModulusOfRcwaMonoid( G, 0 );
     SetMultiplier( G, infinity );
     SetDivisor( G, infinity );
@@ -657,7 +641,7 @@ InstallMethod( CTCons,
                      rec( ) );
     SetIsTrivial( G, false );
     SetOne( G, SparseRep( IdentityRcwaMappingOfZ ) );
-    SetIsNaturalCTP_Z( G, true );
+    SetFilterObj( G, IsNaturalCTP_Z );
     SetModulusOfRcwaMonoid( G, 0 );
     SetMultiplier( G, infinity );
     SetDivisor( G, infinity );
@@ -714,9 +698,9 @@ InstallMethod( CTCons,
                      rec( ) );
     SetIsTrivial( G, false );
     SetOne( G, IdentityRcwaMappingOfZxZ );
-    SetIsNaturalRCWA_OR_CT( G, true );
-    SetIsNaturalCT( G, true );
-    SetIsNaturalCT_ZxZ( G, true );
+    SetFilterObj( G, IsNaturalRCWA_OR_CT );
+    SetFilterObj( G, IsNaturalCT );
+    SetFilterObj( G, IsNaturalCT_ZxZ );
     SetModulusOfRcwaMonoid( G, [ [ 0, 0 ], [ 0, 0 ] ] );
     SetMultiplier( G, infinity );
     SetDivisor( G, infinity );
@@ -759,9 +743,9 @@ InstallMethod( CTCons,
                      rec( ) );
     SetIsTrivial( G, false );
     SetOne( G, id );
-    SetIsNaturalRCWA_OR_CT( G, true );
-    SetIsNaturalCT( G, true );
-    SetIsNaturalCT_Z_pi( G, true );
+    SetFilterObj( G, IsNaturalRCWA_OR_CT );
+    SetFilterObj( G, IsNaturalCT );
+    SetFilterObj( G, IsNaturalCT_Z_pi );
     SetModulusOfRcwaMonoid( G, 0 );
     SetMultiplier( G, infinity );
     SetDivisor( G, infinity );
@@ -801,9 +785,9 @@ InstallMethod( CTCons,
                      rec( ) );
     SetIsTrivial( G, false );
     SetOne( G, id );
-    SetIsNaturalRCWA_OR_CT( G, true );
-    SetIsNaturalCT( G, true );
-    SetIsNaturalCT_GFqx( G, true );
+    SetFilterObj( G, IsNaturalRCWA_OR_CT );
+    SetFilterObj( G, IsNaturalCT );
+    SetFilterObj( G, IsNaturalCT_GFqx );
     SetModulusOfRcwaMonoid( G, Zero( R ) );
     SetMultiplier( G, infinity );
     SetDivisor( G, infinity );
@@ -841,33 +825,6 @@ InstallGlobalFunction( CT,
       return CTCons( IsRcwaGroup, P, R );
     else Error("usage: CT( [ <P>, ], <R> )"); fi;
   end );
-
-#############################################################################
-##
-#M  IsNaturalCT( <G> )  . . . . . . . . . . . . . . . . . . . . . . . . CT(R)
-#M  IsNaturalCT_Z( <G> )  . . . . . . . . . . . . . . . . . . . . . . . CT(Z)
-#M  IsNaturalCTP_Z( <G> ) . . . . . . . . . . . . . . . . . . . . . . CT_P(Z)
-#M  IsNaturalCT_ZxZ( <G> )  . . . . . . . . . . . . . . . . . . . . . CT(Z^2)
-#M  IsNaturalCT_Z_pi( <G> ) . . . . . . . . . . . . . . . . . . .  CT(Z_(pi))
-#M  IsNaturalCT_GFqx( <G> ) . . . . . . . . . . . . . . . . . .  CT(GF(q)[x])
-##
-##  The groups CT( <R> ) can only be obtained by the above constructors.
-##
-Perform( [ IsNaturalCT,
-           IsNaturalCT_Z, IsNaturalCTP_Z, IsNaturalCT_ZxZ,
-           IsNaturalCT_Z_pi, IsNaturalCT_GFqx ],
-         function ( property )
-           InstallMethod( property, "for rcwa groups (RCWA)", true,
-                          [ IsRcwaGroup ], 0, ReturnFalse );
-         end );
-
-#############################################################################
-##
-#M  IsNaturalRCWA_OR_CT( <G> ) . . . . . . . . . . . . . . . RCWA(R) or CT(R)
-##
-InstallMethod( IsNaturalRCWA_OR_CT,
-               "for rcwa groups (RCWA)", true, [ IsRcwaGroup ], 0,
-               ReturnFalse );
 
 #############################################################################
 ##
@@ -2300,7 +2257,7 @@ InstallMethod( IsomorphismRcwaGroup,
     phi := GroupHomomorphismByImagesNC(gl,img);
 
     SetIsBijective(phi,true);
-    SetIsNaturalRcwaRepresentationOfGLOrSL(phi,true);
+    SetFilterObj(phi,IsNaturalRcwaRepresentationOfGLOrSL);
 
     return phi;
   end );
@@ -2324,7 +2281,7 @@ InstallMethod( IsomorphismRcwaGroup,
     phi := GroupHomomorphismByImagesNC(sl,img);
 
     SetIsBijective(phi,true);
-    SetIsNaturalRcwaRepresentationOfGLOrSL(phi,true);
+    SetFilterObj(phi,IsNaturalRcwaRepresentationOfGLOrSL);
 
     return phi;
   end );
@@ -2787,7 +2744,7 @@ InstallMethod( WreathProduct,
 ##
 InstallMethod( Embedding,
                "for a wreath product and 1 or 2 (RCWA)",
-               ReturnTrue, [ HasWreathProductInfo, IsPosInt ], 0,
+               ReturnTrue, [ IsGroup and HasWreathProductInfo, IsPosInt ], 0,
 
   function ( W, i )
     local info;

--- a/lib/rcwagrp.gi
+++ b/lib/rcwagrp.gi
@@ -931,7 +931,7 @@ InstallMethod( IsSubset,
 ## 
 InstallMethod( IsSubset,
                "for CT(Z) and an rcwa group over Z (RCWA)", ReturnTrue,
-               [ IsNaturalCT_Z, IsRcwaGroupOverZ ], SUM_FLAGS,
+               [ IsNaturalCT_Z, IsRcwaGroupOverZ and HasGeneratorsOfGroup ], SUM_FLAGS,
 
   function ( CT_Z, G )
     if not IsClassWiseOrderPreserving(G)
@@ -947,7 +947,7 @@ InstallMethod( IsSubset,
 ## 
 InstallMethod( IsSubset,
                "for CT(R) and an rcwa group (RCWA)", ReturnTrue,
-               [ IsNaturalCT, IsRcwaGroup ], 100,
+               [ IsNaturalCT, IsRcwaGroup and HasGeneratorsOfGroup ], 100,
 
   function ( CT_R, G )
     if FamilyObj(One(G)) <> FamilyObj(One(CT_R)) then return false; fi;

--- a/lib/rcwamap.gd
+++ b/lib/rcwamap.gd
@@ -109,7 +109,7 @@ DeclareGlobalFunction( "RCWAInfo" );
 ##
 ##  The category of all rcwa mappings / -monoids / -groups.
 ##
-DeclareCategory( "IsRcwaMapping", IsRingElement );
+DeclareCategory( "IsRcwaMapping", IsMapping and IsRingElement );
 DeclareSynonym( "IsRcwaMonoid",
                  CategoryCollections(IsRcwaMapping) and IsMonoid );
 DeclareSynonym( "IsRcwaGroup",
@@ -128,11 +128,12 @@ DeclareSynonym( "IsRcwaGroup",
 ##  finite field, respectively. The category `IsRcwaMappingOfZOrZ_pi' is the
 ##  union of the categories `IsRcwaMappingOfZ' and `IsRcwaMappingOfZ_pi'.
 ##
-DeclareCategory( "IsRcwaMappingOfZ", IsRingElement );
-DeclareCategory( "IsRcwaMappingOfZxZ", IsRingElement );
-DeclareCategory( "IsRcwaMappingOfZ_pi", IsRingElement );
-DeclareCategory( "IsRcwaMappingOfGFqx", IsRingElement );
-DeclareCategory( "IsRcwaMappingOfZOrZ_pi", IsRingElement );
+DeclareCategory( "IsRcwaMappingOfZOrZ_pi", IsRcwaMapping );
+DeclareCategory( "IsRcwaMappingOfZ", IsRcwaMappingOfZOrZ_pi );
+DeclareCategory( "IsRcwaMappingOfZxZ", IsRcwaMapping );
+DeclareCategory( "IsRcwaMappingOfZ_pi", IsRcwaMappingOfZOrZ_pi );
+DeclareCategory( "IsRcwaMappingOfGFqx", IsRcwaMapping );
+
 
 #############################################################################
 ##
@@ -840,10 +841,11 @@ DeclareAttribute( "MovedPoints", IsRcwaMonoid );
 #############################################################################
 ##
 #O  \^( <S>, <f> )  . . . . . . . . . image of <S> under the rcwa mapping <f>
-#O  PreImagesSet( <f>, <S> )  . .  preimage of <S> under the rcwa mapping <f>
 ##
 DeclareOperation( "\^", [ IsListOrCollection, IsRcwaMapping ] );
-DeclareOperation( "PreImagesSet", [ IsRcwaMapping, IsList ] );
+if not CompareVersionNumbers(GAPInfo.BuildVersion,"4.10") then
+  DeclareOperation( "PreImagesSet", [ IsRcwaMapping, IsList ] );
+fi;
 
 #############################################################################
 ##

--- a/lib/rcwamap.gi
+++ b/lib/rcwamap.gi
@@ -23,19 +23,6 @@ InstallGlobalFunction( RCWAInfo,
 
 #############################################################################
 ##
-#S  Implications between the categories of rcwa mappings. ///////////////////
-##
-#############################################################################
-
-InstallTrueMethod( IsMapping,     IsRcwaMapping );
-InstallTrueMethod( IsRcwaMapping, IsRcwaMappingOfZOrZ_pi );
-InstallTrueMethod( IsRcwaMappingOfZOrZ_pi, IsRcwaMappingOfZ );
-InstallTrueMethod( IsRcwaMappingOfZOrZ_pi, IsRcwaMappingOfZ_pi );
-InstallTrueMethod( IsRcwaMapping, IsRcwaMappingOfZxZ );
-InstallTrueMethod( IsRcwaMapping, IsRcwaMappingOfGFqx );
-
-#############################################################################
-##
 #S  Shorthands for commonly used filters. ///////////////////////////////////
 ##
 #############################################################################

--- a/lib/rcwamono.gd
+++ b/lib/rcwamono.gd
@@ -53,7 +53,7 @@ DeclareGlobalFunction( "Rcwa" );
 ##
 #P  IsNaturalRcwa( <M> ) . . . . . . . . . . . . . . . . . . . . .  Rcwa( R )
 ##
-DeclareProperty( "IsNaturalRcwa", IsRcwaMonoid );
+DeclareCategory( "IsNaturalRcwa", IsRcwaMonoid );
 
 #############################################################################
 ##

--- a/lib/rcwamono.gi
+++ b/lib/rcwamono.gi
@@ -227,7 +227,7 @@ InstallMethod( RcwaCons,
 
     SetIsTrivial( M, false );
     SetOne( M, id );
-    SetIsNaturalRcwa( M, true );
+    SetFilterObj( M, IsNaturalRcwa );
     SetIsWholeFamily( M, true );
     SetIsFinite( M, false );
     SetSize( M, infinity );
@@ -247,16 +247,6 @@ InstallMethod( RcwaCons,
 #F  Rcwa( <R> ) . . . . . . . . . . . . . . . . . . . . . . . . . . Rcwa( R )
 ##
 InstallGlobalFunction( Rcwa, R -> RcwaCons( IsRcwaMonoid, R ) );
-
-#############################################################################
-##
-#M  IsNaturalRcwa( <M> ) . . . . . . . . . . . . . . . . . . . . . .  Rcwa(R)
-##
-##  The monoids Rcwa( <R> ) can only be obtained by the above constructor.
-##
-InstallMethod( IsNaturalRcwa,
-               "for rcwa monoids (RCWA)", true, [ IsRcwaMonoid ], 0,
-               ReturnFalse );
 
 #############################################################################
 ##


### PR DESCRIPTION
In GAP 4.11, method installations are more closely checked for ambiguities.
This means that RCWA triggers at least one warning when loaded:

    method installed for PreImagesSet matches more than one declaration

To fix this and related things, we remove the PreImagesSet here (at
least in GAP >= 4.10; in GAP <= 4.9 we still needed); we add the
implication IsResidueClass => IsRing, and also refine the category
IsRcwaMapping to be a subset of IsMapping; moreover; several other
categories, like IsRcwaMappingOfZ, are changed to subset IsRcwaMapping
(making several InstallTrueMethod calls redundant).
