### PR TITLE
Ensure IsomorphismPermGroup for IsRcwaGroupOverZ is used

### DIFF
--- a/lib/rcwagrp.gi
+++ b/lib/rcwagrp.gi
@@ -3850,12 +3850,15 @@ InstallMethod( StandardConjugate,
 ##
 InstallMethod( IsomorphismPermGroup,
                "for finite rcwa groups (RCWA)",
-               true, [ IsRcwaGroupOverZ and IsFinite ], 0,
+               true, [ IsRcwaGroupOverZ ], SUM_FLAGS,
 
   function ( G )
 
     local  P, P3, H, phi;
 
+    if not IsFinite(G) then
+      Error("<G> is infinite");
+    fi;
     P   := RespectedPartition(G);
     if   IsClassWiseOrderPreserving(G)
     then H := ActionOnRespectedPartition(G);


### PR DESCRIPTION
Two problems could happen:
- a method for finite abelian groups was ranked higher than this
  if suitable other packages were loaded, as the rank of IsAbelianGroup
  grows then
- if a IsRcwaGroupOverZ does not yet know it is finite, we relied on
  method redispatch for this to be discovered; but if the semigroups
  package is loaded, its method checks for IsFinite, and then produces
  an isomorphism before the RCWA method is reached

Fixes #17