### PR TITLE
Avoid using InstallValue on non-plain objects

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,6 @@ jobs:
           - stable-4.14
           - stable-4.13
           - stable-4.12
-          - stable-4.11
 
     steps:
       - uses: actions/checkout@v5

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -49,7 +49,7 @@ PackageDoc       := rec(
                          LongTitle        := "[R]esidue-[C]lass-[W]ise [A]ffine groups",
                        ),
 Dependencies     := rec(
-                         GAP                    := ">=4.11.1",
+                         GAP                    := ">=4.12.0",
                          NeededOtherPackages    := [ ["ResClasses",">=4.7.2"], ["GRAPE",">=4.7"],
                                                      ["Polycyclic",">=2.11"], ["FR",">=2.2.1"],
                                                      ["GAPDoc",">=1.5.1"], ["Utils",">=0.40"] ],

--- a/lib/rcwagrp.gd
+++ b/lib/rcwagrp.gd
@@ -57,14 +57,6 @@ DeclareRepresentation( "IsRcwaGroupsIteratorRep",
 
 #############################################################################
 ##
-#V  TrivialRcwaGroupOverZ . . . . . . . . . . . . . trivial rcwa group over Z
-#V  TrivialRcwaGroupOverZxZ . . . . . . . . . . . trivial rcwa group over Z^2
-##
-DeclareGlobalVariable( "TrivialRcwaGroupOverZ" );
-DeclareGlobalVariable( "TrivialRcwaGroupOverZxZ" );
-
-#############################################################################
-##
 #S  RCWA(R) and CT(R). //////////////////////////////////////////////////////
 ##
 #############################################################################

--- a/lib/rcwagrp.gi
+++ b/lib/rcwagrp.gi
@@ -369,8 +369,8 @@ InstallMethod( LaTeXStringRcwaGroup,
 #V  TrivialRcwaGroupOverZ . . . . . . . . . . . . . trivial rcwa group over Z
 #V  TrivialRcwaGroupOverZxZ . . . . . . . . . . . trivial rcwa group over Z^2
 ##
-InstallValue( TrivialRcwaGroupOverZ, Group( IdentityRcwaMappingOfZ ) );
-InstallValue( TrivialRcwaGroupOverZxZ, Group( IdentityRcwaMappingOfZxZ ) );
+BindGlobal( "TrivialRcwaGroupOverZ", Group( IdentityRcwaMappingOfZ ) );
+BindGlobal( "TrivialRcwaGroupOverZxZ", Group( IdentityRcwaMappingOfZxZ ) );
 
 #############################################################################
 ##

--- a/lib/rcwamap.gd
+++ b/lib/rcwamap.gd
@@ -326,15 +326,9 @@ DeclareAttribute( "UnderlyingField", IsRcwaMappingOfGFqx );
 
 #############################################################################
 ##
-#V  ZeroRcwaMappingOfZ . . . . . . . . . . . . . . . . zero rcwa mapping of Z
-#V  ZeroRcwaMappingOfZxZ . . . . . . . . . . . . . . zero rcwa mapping of Z^2
-#V  IdentityRcwaMappingOfZ . . . . . . . . . . . . identity rcwa mapping of Z
 #V  IdentityRcwaMappingOfZxZ . . . . . . . . . . identity rcwa mapping of Z^2
 ##
-DeclareGlobalVariable( "ZeroRcwaMappingOfZ" );
-DeclareGlobalVariable( "ZeroRcwaMappingOfZxZ" );
-DeclareGlobalVariable( "IdentityRcwaMappingOfZ" );
-DeclareGlobalVariable( "IdentityRcwaMappingOfZxZ" );
+DeclareGlobalName( "IdentityRcwaMappingOfZxZ" );
 
 #############################################################################
 ##
@@ -499,8 +493,6 @@ DeclareOperation( "SplittedClassTransposition",
 DeclareGlobalFunction( "ClassPairs" );
 DeclareGlobalFunction( "NumberClassPairs" );
 DeclareSynonym( "NrClassPairs", NumberClassPairs );
-DeclareGlobalVariable( "CLASS_PAIRS" );
-DeclareGlobalVariable( "CLASS_PAIRS_LARGE" );
 
 #############################################################################
 ##

--- a/lib/rcwamap.gi
+++ b/lib/rcwamap.gi
@@ -2704,8 +2704,8 @@ InstallGlobalFunction( ClassPairs,
     return tuples;
   end );
 
-InstallValue( CLASS_PAIRS, [ 6, ClassPairs(6) ] );
-InstallValue( CLASS_PAIRS_LARGE, CLASS_PAIRS );
+BindGlobal( "CLASS_PAIRS", [ 6, ClassPairs(6) ] );
+BindGlobal( "CLASS_PAIRS_LARGE", CLASS_PAIRS );
 
 #############################################################################
 ##
@@ -4442,10 +4442,10 @@ InstallMethod( \<,
 #V  ZeroRcwaMappingOfZ . . . . . . . . . . . . . . . . zero rcwa mapping of Z
 #V  ZeroRcwaMappingOfZxZ . . . . . . . . . . . . . . zero rcwa mapping of Z^2
 ##
-InstallValue( ZeroRcwaMappingOfZ, RcwaMapping( [ [ 0, 0, 1 ] ] ) );
+BindGlobal( "ZeroRcwaMappingOfZ", RcwaMapping( [ [ 0, 0, 1 ] ] ) );
 SetIsZero( ZeroRcwaMappingOfZ, true );
 SetImagesSource( ZeroRcwaMappingOfZ, [ 0 ] );
-InstallValue( ZeroRcwaMappingOfZxZ,
+BindGlobal( "ZeroRcwaMappingOfZxZ",
               RcwaMapping( Integers^2, [ [ 1, 0 ], [ 0, 1 ] ],
                            [ [ [ [ 0, 0 ], [ 0, 0 ] ], [ 0, 0 ], 1 ] ] ) );
 SetIsZero( ZeroRcwaMappingOfZxZ, true );
@@ -4535,9 +4535,9 @@ InstallMethod( IsZero, "for rcwa mappings of Z^2 (RCWA)", true,
 #V  IdentityRcwaMappingOfZ . . . . . . . . . . . . identity rcwa mapping of Z
 #V  IdentityRcwaMappingOfZxZ . . . . . . . . . . identity rcwa mapping of Z^2
 ##
-InstallValue( IdentityRcwaMappingOfZ, RcwaMapping( [ [ 1, 0, 1 ] ] ) );
+BindGlobal( "IdentityRcwaMappingOfZ", RcwaMapping( [ [ 1, 0, 1 ] ] ) );
 SetIsOne( IdentityRcwaMappingOfZ, true );
-InstallValue( IdentityRcwaMappingOfZxZ,
+BindGlobal( "IdentityRcwaMappingOfZxZ",
               RcwaMapping( Integers^2, [ [ 1, 0 ], [ 0, 1 ] ],
                            [ [ [ [ 1, 0 ], [ 0, 1 ] ], [ 0, 0 ], 1 ] ] ) );
 SetIsOne( IdentityRcwaMappingOfZxZ, true );

--- a/lib/rcwamono.gd
+++ b/lib/rcwamono.gd
@@ -35,12 +35,6 @@ DeclareSynonym( "IsRcwaMonoidOverZOrZ_pi",
 
 #############################################################################
 ##
-#V  TrivialRcwaMonoidOverZ . . . . . . . . . . . . trivial rcwa monoid over Z
-##
-DeclareGlobalVariable( "TrivialRcwaMonoidOverZ" );
-
-#############################################################################
-##
 #O  RcwaCons( <R> ) . . . . . . . . . . . . . . . . . .  Rcwa( R ) for ring R
 #F  Rcwa( <R> )
 ##

--- a/lib/rcwamono.gi
+++ b/lib/rcwamono.gi
@@ -157,7 +157,7 @@ InstallMethod( Display,
 ##
 #V  TrivialRcwaMonoidOverZ . . . . . . . . . . . . trivial rcwa monoid over Z
 ##
-InstallValue( TrivialRcwaMonoidOverZ, Monoid( IdentityRcwaMappingOfZ ) );
+BindGlobal( "TrivialRcwaMonoidOverZ", Monoid( IdentityRcwaMappingOfZ ) );
 
 #############################################################################
 ##


### PR DESCRIPTION
The pair DeclareGlobalVariable / InstallValue in GAP has unfixable
design issues and arguably should never have been added in the
first place, but that ship has sailed.

The main issue with these functions is with non-plain objects
being used as value. In practice that means using values which are
plain lists, plain records or string objects is acceptable (though
still undesirable). But using a component or positional objects
requires a change of the internal representation of the
placeholder that e.g. prevents safe use in a multi threaded GAP.
Future GAP versions will therefore issues warnings when code
uses InstallValue to do that.

Luckily in many cases it suffices to use BindGlobal. In some cases
one needs to make the name of the variable known to the system
before declaring it. For that, one can use DeclareGlobalName
(introduced in GAP 4.12). This only leaves code that really tries
to access the object before an actual value has been set. In
general such uses are dangerous and should be replaced.
